### PR TITLE
An alternative implementation of PR https://github.com/IBM-Swift/Kitura-TemplateEngine/pull/11

### DIFF
--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -19,7 +19,7 @@ public protocol RenderingOptions {
     static func getOptions(for: TemplateEngine) -> RenderingOptions?
 }
 
-public final class NullRenderingOptions: RenderingOptions {
+public struct NullRenderingOptions: RenderingOptions {
     public static func getOptions(for: TemplateEngine) -> RenderingOptions? {
         return nil
     }

--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -15,16 +15,26 @@
  */
 
 
+public protocol RenderingOptions {
+    static func getOptions(for: TemplateEngine) -> RenderingOptions?
+}
+
+public final class NullRenderingOptions: RenderingOptions {
+    public static func getOptions(for: TemplateEngine) -> RenderingOptions? {
+        return nil
+    }
+}
+
 /// Template Engine protocol for Kitura. Implemented by Templating Engines in order to
 /// integrate with Kitura's content generation APIs.
 ///
 /// - Note: Influenced by http://expressjs.com/en/guide/using-template-engines.html
 public protocol TemplateEngine {
-    
+
     /// The file extension of files in the views directory that will be
     /// rendered by a particular templating engine.
     var fileExtension: String { get }
-    
+
     /// Take a template file and a set of "variables" in the form of a context
     /// and generate content to be sent back to the client.
     ///
@@ -32,5 +42,6 @@ public protocol TemplateEngine {
     ///                      the content.
     /// - Parameter context: A set of variables in the form of a Dictionary of
     ///                     Key/Value pairs, that can be used when generating the content.
-    func render(filePath: String, context: [String: Any]) throws -> String
+    func render(filePath: String, context: [String: Any], options:
+                    RenderingOptions = NullRenderingOptions()) throws -> String
 }

--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -49,15 +49,15 @@ public protocol TemplateEngine {
     ///                     Key/Value pairs, that can be used when generating the content.
     /// - Parameter options: rendering options, different per each template engine
     ///
-    func render(filePath: String, context: [String: Any], options:
-                    RenderingOptions) throws -> String
+    func render(filePath: String, context: [String: Any],
+                options: RenderingOptions) throws -> String
 }
 
 extension TemplateEngine {
     // implementation of render with options parameter for TemplateEngines
     // that did not implement it
-    func render(filePath: String, context: [String: Any], options:
-                    RenderingOptions) throws -> String {
+    func render(filePath: String, context: [String: Any],
+                options: RenderingOptions) throws -> String {
         return try render(filePath: filePath, context: context)
     }
 }

--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -56,8 +56,8 @@ public protocol TemplateEngine {
 extension TemplateEngine {
     // implementation of render with options parameter for TemplateEngines
     // that did not implement it
-    func render(filePath: String, context: [String: Any],
-                options: RenderingOptions) throws -> String {
+    public func render(filePath: String, context: [String: Any],
+                       options: RenderingOptions) throws -> String {
         return try render(filePath: filePath, context: context)
     }
 }

--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -17,7 +17,9 @@
 
 public protocol RenderingOptions {}
 
-public struct NullRenderingOptions: RenderingOptions {}
+public struct NullRenderingOptions: RenderingOptions {
+    public init() {}
+}
 
 /// Template Engine protocol for Kitura. Implemented by Templating Engines in order to
 /// integrate with Kitura's content generation APIs.

--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -42,6 +42,26 @@ public protocol TemplateEngine {
     ///                      the content.
     /// - Parameter context: A set of variables in the form of a Dictionary of
     ///                     Key/Value pairs, that can be used when generating the content.
+    func render(filePath: String, context: [String: Any]) throws -> String
+
+    /// Take a template file and a set of "variables" in the form of a context
+    /// and generate content to be sent back to the client.
+    ///
+    /// - Parameter filePath: The path of the template file to use when generating
+    ///                      the content.
+    /// - Parameter context: A set of variables in the form of a Dictionary of
+    ///                     Key/Value pairs, that can be used when generating the content.
+    /// - Parameter options: rendering options, different per each template engine
+    ///
     func render(filePath: String, context: [String: Any], options:
-                    RenderingOptions = NullRenderingOptions()) throws -> String
+                    RenderingOptions) throws -> String
+}
+
+extension TemplateEngine {
+    // implementation of render with options parameter for TemplateEngines
+    // that did not implement it
+    func render(filePath: String, context: [String: Any], options:
+                    RenderingOptions) throws -> String {
+        return try render(filePath: filePath, context: context)
+    }
 }

--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -15,15 +15,9 @@
  */
 
 
-public protocol RenderingOptions {
-    static func getOptions(for: TemplateEngine) -> RenderingOptions?
-}
+public protocol RenderingOptions {}
 
-public struct NullRenderingOptions: RenderingOptions {
-    public static func getOptions(for: TemplateEngine) -> RenderingOptions? {
-        return nil
-    }
-}
+public struct NullRenderingOptions: RenderingOptions {}
 
 /// Template Engine protocol for Kitura. Implemented by Templating Engines in order to
 /// integrate with Kitura's content generation APIs.


### PR DESCRIPTION
This PR uses `RenderingOptions` protocol for options, instead of `[String: Any]`. Also, it does not break the existing TemplateEngine implementations, since it adds a new function with `options` parameter, and adds an extension that implements that function.

See https://github.com/vadimeisenbergibm/Kitura-Markdown for an example of using options. Once this PR is merged, I will submit a PR for https://github.com/vadimeisenbergibm/Kitura-Markdown .

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.