### PR TITLE
IBM-Swift/Kitura-StencilTemplateEngine#16 added overloaded render() and setRootPaths()

### DIFF
--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -75,14 +75,14 @@ public protocol TemplateEngine {
 
 extension TemplateEngine {
     // implementation of render with options parameter for TemplateEngines
-    // that did not implement it
+    // that do not implement it
     public func render(filePath: String, context: [String: Any],
                        options: RenderingOptions) throws -> String {
         return try render(filePath: filePath, context: context)
     }
 
     // implementation of render with options and templateName parameter for TemplateEngines
-    // that did not implement it
+    // that do not implement it
     public func render(filePath: String, context: [String: Any],
                        options: RenderingOptions, templateName: String) throws -> String {
         return try render(filePath: filePath, context: context, options: options)

--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -85,7 +85,7 @@ extension TemplateEngine {
     // that did not implement it
     public func render(filePath: String, context: [String: Any],
                        options: RenderingOptions, templateName: String) throws -> String {
-        return try render(filePath: filePath, context: context)
+        return try render(filePath: filePath, context: context, options: options)
     }
 
     // implementation of setRootPaths for TemplateEngines that do not implement it

--- a/Sources/KituraTemplateEngine/TemplateEngine.swift
+++ b/Sources/KituraTemplateEngine/TemplateEngine.swift
@@ -51,6 +51,26 @@ public protocol TemplateEngine {
     ///
     func render(filePath: String, context: [String: Any],
                 options: RenderingOptions) throws -> String
+
+    /// Take a template file and a set of "variables" in the form of a context
+    /// and generate content to be sent back to the client.
+    ///
+    /// - Parameter filePath: The path of the template file to use when generating
+    ///                      the content.
+    /// - Parameter context: A set of variables in the form of a Dictionary of
+    ///                     Key/Value pairs, that can be used when generating the content.
+    /// - Parameter options: rendering options, different per each template engine
+    ///
+    /// - Parameter templateName: the name of the template
+    ///
+    func render(filePath: String, context: [String: Any],
+                options: RenderingOptions, templateName: String) throws -> String
+
+    /// Set root paths for the template engine - the paths where the included templates can be
+    /// searched
+    ///
+    /// - Parameter rootPaths: the paths where the included templates can be
+    func setRootPaths(rootPaths: [String])
 }
 
 extension TemplateEngine {
@@ -60,4 +80,14 @@ extension TemplateEngine {
                        options: RenderingOptions) throws -> String {
         return try render(filePath: filePath, context: context)
     }
+
+    // implementation of render with options and templateName parameter for TemplateEngines
+    // that did not implement it
+    public func render(filePath: String, context: [String: Any],
+                       options: RenderingOptions, templateName: String) throws -> String {
+        return try render(filePath: filePath, context: context)
+    }
+
+    // implementation of setRootPaths for TemplateEngines that do not implement it
+    public func setRootPaths(rootPaths: [String]) {}
 }


### PR DESCRIPTION
…nd setRootPaths()

render(filePath: context: options: templateName:)
setRootPaths(rootPaths:)

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
