### PR TITLE
Restore swift 3.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,26 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      env: SWIFT_SNAPSHOT=3.1.1
+    - os: linux
+      dist: trusty
+      sudo: required
+    - os: linux
+      dist: trusty
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+    - os: osx
+      osx_image: xcode8.3
+      sudo: required
+      env: SWIFT_SNAPSHOT=3.1.1
     - os: osx
       osx_image: xcode9.2
       sudo: required
+    - os: osx
+      osx_image: xcode9.3beta
+      sudo: required
+      env: SWIFT_SNAPSHOT=4.1-DEVELOPMENT-SNAPSHOT-2018-02-26-a
+
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Travis CI build file for Kitura-TemplateEngine.
 # Kitura runs on OS X and Linux (Ubuntu v14.04).
 
-# whitelist (branches that should be built)
+# whitelist (branches that should be built) 
 branches:
   only:
     - master

--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,5 @@
+{
+  "autoPin": false,
+  "pins": [],
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,3 @@
-// swift-tools-version:4.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
-
 /**
  * Copyright IBM Corporation 2016, 2017
  *
@@ -20,19 +17,5 @@
 import PackageDescription
 
 let package = Package(
-    name: "Kitura-TemplateEngine",
-    products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
-        .library(
-            name: "KituraTemplateEngine",
-            targets: ["KituraTemplateEngine"]
-        )
-    ],
-    targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
-        .target(
-            name: "KituraTemplateEngine"
-        )
-    ]
+    name: "Kitura-TemplateEngine"
 )

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:4.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+/**
+ * Copyright IBM Corporation 2016, 2017
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+import PackageDescription
+
+let package = Package(
+    name: "Kitura-TemplateEngine",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "KituraTemplateEngine",
+            targets: ["KituraTemplateEngine"]
+        )
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "KituraTemplateEngine"
+        )
+    ]
+)


### PR DESCRIPTION
As it is not necessary to drop support for Swift 3.1.1 at this time, this PR
- restores the Swift 3 `Package.swift`,
- introduces a `Package@swift-4.swift` which will be used by the 4.0 and 4.1 Swift releases, and
- enables Travis builds against 3.1.1, 4.0 and 4.1 releases.

There are no tests defined in this project, so the Travis is purely to demonstrate that the code builds on each release we support.