### PR TITLE
Fix: badge rename to macOS from Mac OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <a href="https://travis-ci.org/IBM-Swift/Kitura-TemplateEngine">
 <img src="https://travis-ci.org/IBM-Swift/Kitura-TemplateEngine.svg?branch=master" alt="Build Status - Master">
 </a>
-<img src="https://img.shields.io/badge/os-Mac%20OS%20X-green.svg?style=flat" alt="Mac OS X">
+<img src="https://img.shields.io/badge/os-macOS-green.svg?style=flat" alt="macOS">
 <img src="https://img.shields.io/badge/os-linux-green.svg?style=flat" alt="Linux">
 <img src="https://img.shields.io/badge/license-Apache2-blue.svg?style=flat" alt="Apache 2">
 <a href="http://swift-at-ibm-slack.mybluemix.net/">


### PR DESCRIPTION
## Motivation and Context
We should be referring to macOS and not Mac OS X.

## How Has This Been Tested?
README.md was loaded into the browser.
